### PR TITLE
Add HTTP Basic Authentication option for SOLR Web Console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer="Denys Vuika <denys.vuika@alfresco.com>"
 
 COPY nginx.conf /etc/nginx/nginx.conf
 
+VOLUME [ "/etc/nginx/auth" ]
+
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A proxy container for ACS deployment with Alfresco Digital Workspace support.
 | ADW_URL | `http://digital-workspace` | Digital Workspace URL inside network. |
 | REPO_URL | `http://alfresco:8080` | Repository URL inside network. |
 | SHARE_URL | `http://share:8080` | Share URL inside network. |
+| SOLR_URL | `http://solr6:8983` | SOLR URL inside network. |
 | ACCESS_LOG | n/a | Set the `access_log` value. Set to `off` to switch off logging. |
 
 ## Examples
@@ -22,6 +23,28 @@ docker run \
   --rm -p 80:80/tcp \
   alfresco/alfresco-acs-nginx:3.0.1
 ```
+
+When using `SOLR_URL` an external [NGINX Password file](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basic-authentication/) named `nginx.htpasswd` is required, as SOLR Web Console is unprotected by default.
+
+Sample Password File for "admin/admin" credentials
+
+```
+admin:YWG41BPzVAkN6
+```
+
+Sample invocation exposing SOLR Web Console with HTTP Basic Authentication
+```sh
+docker run \
+  -v $PWD/nginx.htpasswd:/etc/nginx/auth/nginx.htpasswd \
+  -e ADW_URL="http://digital-workspace:8091" \
+  -e REPO_URL="http://alfresco:8092" \
+  -e SHARE_URL="http://share:8093" \
+  -e SOLR_URL="http://solr6:8983" \
+  -e ACCESS_LOG="off" \
+  --rm -p 80:80/tcp \
+  alfresco/alfresco-acs-nginx:3.0.1
+```
+
 
 Using with docker-compose:
 
@@ -44,6 +67,10 @@ digital-workspace-ingress:
     #     ADW_URL: "http://digital-workspace"
     #     REPO_URL: "http://alfresco:8080"
     #     SHARE_URL: "http://share:8080"
+    #     SOLR_URL: "http://solr6:8983"
+    # volumes:
+    #     - ./nginx.htpasswd:/etc/nginx/auth/nginx.htpasswd
+
 ```
 
 ## Continuous Integration

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,14 @@ if [[ $ACCESS_LOG ]]; then
   sed -i s%\#ENV_ACCESS_LOG%"access_log $ACCESS_LOG;"%g /etc/nginx/nginx.conf
 fi
 
+if [[ $SOLR_URL ]]; then
+  sed -i s%\#SOLR_WEB_CONSOLE%" \
+location /solr/ { \n\
+            proxy_pass $SOLR_URL; \n\
+            auth_basic \"Solr web console\"; \n\
+            auth_basic_user_file /etc/nginx/auth/nginx.htpasswd; \n\
+        } \n\
+  "%g /etc/nginx/nginx.conf
+fi
+
 nginx -g "daemon off;"

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,10 +33,10 @@ http {
 
         location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
         location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}
-        
+
         # Protect access to Prometheus endpoint
         location ~ ^(/.*/s/prometheus)$ {return 403;}
-        
+
         location / {
             proxy_pass http://alfresco:8080;
         }
@@ -52,5 +52,9 @@ http {
         location /share/ {
             proxy_pass http://share:8080;
         }
+
+        # External settings, do not remove
+        #SOLR_WEB_CONSOLE
+
     }
 }


### PR DESCRIPTION
nginx.htpasswd is not provided by default to protect users from deploy accidentally "admin/admin" authenticated services.