### PR TITLE
Proposed fix for timeout if/when using external proxy / load balancer…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -43,14 +43,23 @@ http {
 
         location /workspace/ {
             proxy_pass http://digital-workspace:8080/;
+
+            # If using external proxy / load balancer (for initial redirect if no trailing slash)
+            absolute_redirect off;
         }
 
         location /alfresco/ {
             proxy_pass http://alfresco:8080;
+
+            # If using external proxy / load balancer (for initial redirect if no trailing slash)
+            absolute_redirect off;
         }
 
         location /share/ {
             proxy_pass http://share:8080;
+
+            # If using external proxy / load balancer (for initial redirect if no trailing slash)
+            absolute_redirect off;
         }
         
         location /syncservice/ {


### PR DESCRIPTION
… (with ssl termination) for initial 301 redirect when no trailing slash

- issue noticed when using top-level https://my.domain page which has "Alfresco Repository" link to https://my.domain/alfresco 
- clicking on that link timed out due to invalid redirect to http://my.domain:8080/alfresco/
- without this fix top-level urls without trailing slash will 301 redirect to wrong *scheme* and *port* (and hence timeout)
- for example urls such as: https://my.domain/alfresco, https://my.domain/share, https://my.domain/workspace ...
- ... before fix redirect to invalid: http://my.domain:8080/alfresco/, http://my.domain:8080/share/, http://my.domain:8080/workspace/
- ... after fix redirect to valid: https://my.domain/alfresco/, https://my.domain/share/, https://my.domain/workspace/