### PR TITLE
OPSEXP-755: Disable prometheus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
 before_script:
   - echo "TRAVIS_COMMIT_MESSAGE=$TRAVIS_COMMIT_MESSAGE"
   - export IMAGE_NAME=alfresco/alfresco-acs-nginx
-  - export IMAGE_TAG=3.1.0
+  - export IMAGE_TAG=3.1.1
 
 script:
   - echo "Building and tagging $IMAGE_NAME:$IMAGE_TAG..."

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A proxy container for ACS deployment with Alfresco Digital Workspace and Sync Se
 | DISABLE_ADW | `false` | Disables ADW if set to `"true"` |
 | DISABLE_SHARE | `false` | Disables Share if set to `"true"` |
 | DISABLE_SYNCSERVICE | `false` | Disables Sync Service if set to `"true"` |
+| DISABLE_PROMETHEUS | `false` | Disables Prometheus if set to `"true"` |
 | ACCESS_LOG | n/a | Set the `access_log` value. Set to `off` to switch off logging. |
 
 ## Examples
@@ -59,6 +60,7 @@ proxy:
     image: alfresco/alfresco-acs-nginx:3.1.0
     mem_limit: 128m
     environment:
+        DISABLE_PROMETHEUS: "true"
         DISABLE_SYNCSERVICE: "true"
         DISABLE_ADW: "true"
     depends_on:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,10 @@ if [[ "$DISABLE_SYNCSERVICE" != "true" ]]; then
   sed -i s%\#SYNCSERVICE_LOCATION%"location /syncservice/ {\n            proxy_pass http://sync-service:9090/alfresco/;\n        }"%g /etc/nginx/nginx.conf
 fi
 
+if [[ "$DISABLE_PROMETHEUS" != "true" ]]; then
+  sed -i s%\#PROMETHEUS_LOCATION%"location ~ ^(/.*/s/prometheus)$ {return 403;}"%g /etc/nginx/nginx.conf
+fi
+
 if [[ $ADW_URL ]]; then
   sed -i s%http:\/\/digital-workspace:8080%"$ADW_URL"%g /etc/nginx/nginx.conf
 fi

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,8 +34,8 @@ http {
         location ~ ^(/.*/proxy/.*/api/solr/.*)$ {return 403 ;}
         location ~ ^(/.*/-default-/proxy/.*/api/.*)$ {return 403;}
         
-        # Protect access to Prometheus endpoint
-        location ~ ^(/.*/s/prometheus)$ {return 403;}
+        # Prometheus settings, do not remove
+        #PROMETHEUS_LOCATION
         
         location / {
             proxy_pass http://alfresco:8080;


### PR DESCRIPTION
Added the ability to disable the Prometheus URL for backwards compatibility with community nginx image.