### PR TITLE
Update entrypoint.sh so proxy can listen on a port other than 8080

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [[ "$DISABLE_SHARE" != "true" ]]; then
-  sed -i s%\#SHARE_LOCATION%"location /share/ {\n            proxy_pass http://share:8080;\n            absolute_redirect off;\n        }"%g /etc/nginx/nginx.conf
+  sed -i s%\#SHARE_LOCATION%"location /share/ {\n            proxy_pass http://share:8080;\n            proxy_set_header Host \$host;\n            absolute_redirect off;\n        }"%g /etc/nginx/nginx.conf
 fi
 
 if [[ "$DISABLE_ADW" != "true" ]]; then


### PR DESCRIPTION
Prior to this change, if the proxy is configured to listen on say port 80 and you goto http://localhost/share, you will be redirected to http://localhost:8080/share/page/. This is because nginx is fowarding `localhost:8080` to Share's Tomcat and when Share creates fully qualified URLs, it includes the port that should be hidden by nginx.