### PR TITLE
Fix redirects when using external reverse-proxy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,7 @@ http {
         proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
         proxy_redirect off;
         proxy_buffering off;
-        proxy_set_header Host            $host:$server_port;
+        proxy_set_header Host            $http_host;
         proxy_set_header X-Real-IP       $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass_header Set-Cookie;


### PR DESCRIPTION
When nginx is behind an external reverse-proxy, some redirects use the internal port (8080) instead of the real port (443).

For example, with https://acs.example.com/ as my external URL, when accessing https://acs.example.com/share/ I got redirected to https://acs.example.com:8080/share/page/ instead of https://acs.example.com/share/page/.

This is because `proxy_set_header Host` is set to `$host:$server_port`. The `$server_port` should not be used here because it's not always the same as the real port used on the external reverse-proxy. Instead, the `$http_host` variable should be used as this variable is set to the `Host` HTTP Header set by the external reverse-proxy. This variable contains the real hostname and port.