### PR TITLE
ACA-3221: Modifying /content-app proxy link to /aca

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ if [[ "$DISABLE_PROMETHEUS" != "true" ]]; then
 fi
 
 if [[ "$ENABLE_CONTENT_APP" == "true" ]]; then
-  sed -i s%\#ACA_LOCATION%"location /content-app/ {\n            proxy_pass http://content-app:8080/;\n            absolute_redirect off;\n        }"%g /etc/nginx/nginx.conf
+  sed -i s%\#ACA_LOCATION%"location /aca/ {\n            proxy_pass http://content-app:8080/;\n            absolute_redirect off;\n        }"%g /etc/nginx/nginx.conf
 fi
 
 if [[ $ADW_URL ]]; then


### PR DESCRIPTION
Demo application shows ACA under /aca/ subaddress, not at as I've done, under /content-app/. Changing it to /aca/ to keep it consistent